### PR TITLE
order households by recent activity

### DIFF
--- a/app/controllers/households_controller.rb
+++ b/app/controllers/households_controller.rb
@@ -2,9 +2,10 @@ class HouseholdsController < ApplicationController
   # GET /households
   # GET /households.xml
   def index
-    @households = Household.active
     if params[:search]
-      @households = @households.find_by_keywords(params[:search])
+      @households = Household.find_by_keywords(params[:search])
+    else
+      @households = Household.active.by_recent_activity
     end
 
     respond_to do |format|

--- a/app/models/household.rb
+++ b/app/models/household.rb
@@ -22,8 +22,8 @@ class Household < ActiveRecord::Base
 
   # All households with no members
   scope :empty, joins('left outer join members on members.household_id = households.id').select('households.*').where('members.id is null')
-
   scope :active, joins(:members).where(:members => { :active => true }).includes(:members)
+  scope :by_recent_activity, joins(:transactions).order('transactions.created_at DESC')
 
   def to_s
     if members.empty?
@@ -41,6 +41,10 @@ class Household < ActiveRecord::Base
   def debit! (amount)
     transactions.create!(:credit => false, :amount => amount)
     self.update_attribute(:balance, self.balance - amount)
+  end
+
+  def last_transaction
+    transactions.order('created_at').last
   end
 
   comma do

--- a/app/views/households/index.html.erb
+++ b/app/views/households/index.html.erb
@@ -14,8 +14,8 @@
 <table id="households">
   <tr>
     <th>Members</th>
-    <th class="money">Balance</th>
-    <th></th>
+    <th>Last seen</th>
+    <th colspan=2 class="money">Balance</th>
   </tr>
 
 <% @households.each do |household| %>
@@ -27,8 +27,15 @@
       <% end %>
       </ol>
     </td>
+    <td>
+      <% if household.last_transaction %>
+        <%= time_ago_in_words(household.last_transaction.created_at) %> ago
+      <% else %>
+        No financial record.
+      <% end %>
+    </td>
     <td class="money"><%= sprintf("$%.2f", household.balance) %></td>
-    <td><%= link_to 'Investment/Purchase', household %></td>
+    <td><%= link_to '+/-', household %></td>
   </tr>
 <% end %>
 </table>

--- a/spec/models/household_spec.rb
+++ b/spec/models/household_spec.rb
@@ -37,7 +37,34 @@ describe Household do
     end
   end
 
+  describe "#last_transaction" do
+    subject { household.last_transaction }
+
+    let(:household) { FactoryGirl.create(:household) }
+    context "with a couple transactions" do
+      let!(:first_transaction) { FactoryGirl.create(:purchase, household: household) }
+      let!(:second_transaction) { FactoryGirl.create(:purchase, household: household) }
+      it { should == second_transaction }
+    end
+  end
+
   pending "should be impossible to change balance without creating a transaction"
+
+  describe ".by_recent_activity" do
+    subject { Household.by_recent_activity }
+
+    let!(:never_seen_this_household) { FactoryGirl.create(:household) }
+
+    let!(:saw_this_household_a_bit_ago) do
+      FactoryGirl.create(:purchase).household
+    end
+
+    let!(:saw_this_household_just_now) do
+      FactoryGirl.create(:purchase).household
+    end
+
+    it { should == [saw_this_household_just_now, saw_this_household_a_bit_ago] }
+  end
 
   describe ".find_by_keywords" do
     before(:all) do


### PR DESCRIPTION
@lauraerinmann - I'm considering doing this instead of the feature we were working on this summer.

https://github.com/michaelkirk/household-account-mgmt/compare/feature/only_show_recent_households

I think this is simpler and solves the same problem - being able to see who has been recently active.

What do you think?
